### PR TITLE
change cuda version from 118 to 121

### DIFF
--- a/notebooks/pytorch-mask-r-cnn-training-colab.ipynb
+++ b/notebooks/pytorch-mask-r-cnn-training-colab.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%capture\n",
     "# Install PyTorch with CUDA\n",
-    "!pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118\n",
+    "!pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121\n",
     "\n",
     "# Install additional dependencies\n",
     "!pip install matplotlib pandas pillow torchtnt==0.2.0 tqdm tabulate\n",


### PR DESCRIPTION
I found an error while trying to use the collab notebook.
```
RuntimeError: Detected that PyTorch and torchvision were compiled with different CUDA major versions. PyTorch has CUDA Version=11.8 and torchvision has CUDA Version=12.1. Please reinstall the torchvision that matches your PyTorch install.
```

**Old**
```bash
!pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
```

**New**
```bash
!pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
```


This new line works for me.